### PR TITLE
Handle missing PCAP path

### DIFF
--- a/pcap_utils.py
+++ b/pcap_utils.py
@@ -8,7 +8,11 @@ except Exception:  # scapy may be stubbed in tests
 
 def load_pcap_fast(pcap_path):
     """Efficiently load packets from a PCAP using RawPcapReader."""
-    file_size = os.path.getsize(pcap_path)
+    try:
+        file_size = os.path.getsize(pcap_path)
+    except FileNotFoundError:
+        print(f"❌ File not found: {pcap_path}")
+        return []
     packets = []
 
     if RawPcapReader is None or RadioTap is None:

--- a/tests/test_pcap_utils.py
+++ b/tests/test_pcap_utils.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+import importlib
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def import_pcap_utils():
+    modules = {}
+    scapy_all = types.ModuleType('scapy.all')
+    scapy_all.RawPcapReader = lambda *a, **k: iter([])
+    scapy_all.RadioTap = lambda *a, **k: None
+    scapy = types.ModuleType('scapy')
+    scapy.all = scapy_all
+    modules['scapy'] = scapy
+    modules['scapy.all'] = scapy_all
+    for name, mod in modules.items():
+        sys.modules[name] = mod
+    return importlib.reload(importlib.import_module('pcap_utils'))
+
+
+def test_load_pcap_fast_nonexistent(tmp_path):
+    pu = import_pcap_utils()
+    result = pu.load_pcap_fast(str(tmp_path / 'missing.pcap'))
+    assert result == []


### PR DESCRIPTION
## Summary
- handle missing pcap file errors in `load_pcap_fast`
- add regression test for nonexistent pcap path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b100e620832da2b512f7c3af3c3b