### PR TITLE
Add optional dpkt support for faster pcap loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ openai
 anthropic
 pick
 tqdm
+dpkt
 ```
+`dpkt` is optional but speeds up packet loading in `pcap_utils.load_pcap_fast`.
+If not installed, the function falls back to Scapy's `RawPcapReader`.
 5. Set Up API Keys
 Create a file named .env in the root of the project directory. Add your API keys, ensuring they are enclosed in quotes:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openai
 anthropic
 pick
 tqdm
+dpkt

--- a/tests/test_pcap_utils.py
+++ b/tests/test_pcap_utils.py
@@ -8,13 +8,60 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 def import_pcap_utils():
     modules = {}
+    sys.modules.pop('dpkt', None)
+
+    class DummyRawReader:
+        def __init__(self, *a, **k):
+            self.pkts = [b'c', b'd']
+            self.offset = 0
+            self.f = types.SimpleNamespace(tell=lambda: 0)
+
+        def __iter__(self):
+            for p in self.pkts:
+                yield p, None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
     scapy_all = types.ModuleType('scapy.all')
-    scapy_all.RawPcapReader = lambda *a, **k: iter([])
-    scapy_all.RadioTap = lambda *a, **k: None
+    scapy_all.RawPcapReader = DummyRawReader
+    scapy_all.RadioTap = lambda buf: ('RT', buf)
     scapy = types.ModuleType('scapy')
     scapy.all = scapy_all
     modules['scapy'] = scapy
     modules['scapy.all'] = scapy_all
+
+    for name, mod in modules.items():
+        sys.modules[name] = mod
+    return importlib.reload(importlib.import_module('pcap_utils'))
+
+
+def import_pcap_utils_with_dpkt():
+    modules = {}
+
+    scapy_all = types.ModuleType('scapy.all')
+    scapy_all.RawPcapReader = lambda *a, **k: iter([])
+    scapy_all.RadioTap = lambda buf: ('RT', buf)
+    scapy = types.ModuleType('scapy')
+    scapy.all = scapy_all
+    modules['scapy'] = scapy
+    modules['scapy.all'] = scapy_all
+
+    dpkt = types.ModuleType('dpkt')
+
+    class DummyReader:
+        def __init__(self, f):
+            pass
+
+        def __iter__(self):
+            return iter([(0, b'a'), (1, b'b')])
+
+    dpkt.pcap = types.SimpleNamespace(Reader=DummyReader)
+    modules['dpkt'] = dpkt
+
     for name, mod in modules.items():
         sys.modules[name] = mod
     return importlib.reload(importlib.import_module('pcap_utils'))
@@ -24,3 +71,19 @@ def test_load_pcap_fast_nonexistent(tmp_path):
     pu = import_pcap_utils()
     result = pu.load_pcap_fast(str(tmp_path / 'missing.pcap'))
     assert result == []
+
+
+def test_load_pcap_fast_with_dpkt(tmp_path):
+    p = tmp_path / "file.pcap"
+    p.write_bytes(b"data")
+    pu = import_pcap_utils_with_dpkt()
+    result = pu.load_pcap_fast(str(p))
+    assert result == [('RT', b'a'), ('RT', b'b')]
+
+
+def test_load_pcap_fast_fallback(tmp_path):
+    p = tmp_path / "file2.pcap"
+    p.write_bytes(b"data")
+    pu = import_pcap_utils()
+    result = pu.load_pcap_fast(str(p))
+    assert result == [('RT', b'c'), ('RT', b'd')]


### PR DESCRIPTION
## Summary
- optionally use `dpkt` in `load_pcap_fast`
- add `dpkt` to requirements
- test both dpkt and fallback paths
- document optional dpkt dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b2176290832d99fec580ae83ab2e