### PR TITLE
Add chunked pcap reader

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -15,7 +15,7 @@ import multiprocessing
 
 # Scapy imports, including the pcap writer
 from scapy.all import PcapWriter, Dot11, Dot11Auth, Dot11Deauth, Dot11Disas, Dot11Beacon, Dot11ProbeReq, Dot11ProbeResp, EAPOL, Dot11AssoReq, RadioTap, Dot11Elt, ARP, DNS, DHCP, BOOTP
-from pcap_utils import load_pcap_fast
+from pcap_utils import load_pcap_in_chunks
 from tqdm import tqdm
 from pick import pick
 
@@ -373,7 +373,7 @@ def _process_single_pcap(pcap_file, scan_plan):
     output_lines.append("\n" + "=" * 60)
     output_lines.append(f"📄 Scanning: {os.path.basename(pcap_file)}")
 
-    packets = load_pcap_fast(pcap_file)
+    packets = load_pcap_in_chunks(pcap_file, chunk_count=10)
     if not packets:
         return "\n".join(output_lines)
 

--- a/tests/test_pcap_utils.py
+++ b/tests/test_pcap_utils.py
@@ -87,3 +87,17 @@ def test_load_pcap_fast_fallback(tmp_path):
     pu = import_pcap_utils()
     result = pu.load_pcap_fast(str(p))
     assert result == [('RT', b'c'), ('RT', b'd')]
+
+
+def test_load_pcap_in_chunks(tmp_path):
+    p = tmp_path / "chunk.pcap"
+    p.write_bytes(b"data")
+    pu = import_pcap_utils()
+    result = pu.load_pcap_in_chunks(str(p), chunk_count=10)
+    assert result == [('RT', b'c'), ('RT', b'd')]
+
+
+def test_load_pcap_in_chunks_missing(tmp_path):
+    pu = import_pcap_utils()
+    result = pu.load_pcap_in_chunks(str(tmp_path / 'none.pcap'), chunk_count=10)
+    assert result == []


### PR DESCRIPTION
## Summary
- load pcap files in smaller chunks with new `load_pcap_in_chunks`
- use chunked loader inside `scan.py`
- test the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850be2933d0832dbea287eea3812e0b